### PR TITLE
Resolve write issue when EnableCSRFDefense is TRUE

### DIFF
--- a/osisoft-web-api.js
+++ b/osisoft-web-api.js
@@ -91,7 +91,8 @@ module.exports = function (RED) {
         url: protocol + node.server.baseUrl + url,
         headers: {
           'Authorization': node.server.generateAuth(),
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+	  'X-Requested-With' : 'XMLHttpRequest' //Proposed add-in to Allow Write data connection via pi web api to PI when "EnableCSRFDefense": true
         },
         json:true,
         "Cache-Control": "no-cache",


### PR DESCRIPTION
Added at line 95
******************
'X-Requested-With' : 'XMLHttpRequest' //Proposed to add-in to Allow Write data connection via pi web api to PI Server when the configuration item in PI System Explorer "EnableCSRFDefense": true.
******************

When set to true, the Cross-Site Request Forgery (CSRF) defense is enabled in PI Web API, and PI Web API checks whether a custom HTTP request header X-Requested-With is present with a request, whose method is POST, PUT, PATCH or DELETE. This defense relies on the Same-Origin Policy restriction and CORS settings. Ensure that the value for the CorsHeaders setting is either the asterisk (*) character or contains X-Requested-With.

cited from: [OSISOFT Live Library EnableCSRFDefense](https://livelibrary.osisoft.com/LiveLibrary/content/en/web-api-v9/GUID-E8BF02E2-77C1-40B1-9F1F-0637F94BB8B9#addHistory=true&filename=GUID-795C947E-C220-4521-8827-F7840CFE0DEA.xml&docid=GUID-E8BF02E2-77C1-40B1-9F1F-0637F94BB8B9&inner_id=&tid=&query=&scope=&resource=&toc=false&eventType=lcContent.loadDocGUID-E8BF02E2-77C1-40B1-9F1F-0637F94BB8B9)